### PR TITLE
Add ReadHeaderTimeout to health-check HTTP server (slow-loris defence)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -151,12 +151,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create HTTP server for health checks
+	// Create HTTP server for health checks.
+	// ReadHeaderTimeout is set to protect against slow-loris connections that
+	// trickle HTTP request headers without ever completing them. Without it,
+	// ReadTimeout alone does not bound header-only connections because
+	// ReadTimeout begins only after the first body byte arrives.
 	httpServer := &http.Server{
-		Addr:         ":" + httpPort,
-		Handler:      newHealthHandler(log),
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 5 * time.Second,
+		Addr:              ":" + httpPort,
+		Handler:           newHealthHandler(log),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      5 * time.Second,
 	}
 
 	// Start HTTP server in goroutine


### PR DESCRIPTION
## Problem

The HTTP server in `cmd/server/main.go` that serves health-check endpoints (`/`, `/health`, `/ready`) was created with `ReadTimeout` and `WriteTimeout` set, but **missing `ReadHeaderTimeout`**:

```go
// BEFORE
httpServer := &http.Server{
    Addr:         ":" + httpPort,
    Handler:      newHealthHandler(log),
    ReadTimeout:  5 * time.Second,
    WriteTimeout: 5 * time.Second,
}
```

`ReadHeaderTimeout` is the primary defence against **slow-loris attacks**: a client that connects and trickles HTTP request headers one byte at a time will hold the TCP connection open indefinitely, because `ReadTimeout` only starts counting once the first byte of the *body* has been received — pure-header dribbling is not bounded.

Although this is a health-check-only server (not the gRPC API), the vulnerability is real: under enough slow-loris connections the server exhausts its file descriptor budget and becomes unavailable to legitimate load balancers and monitoring agents, which then mark the service as unhealthy.

## Fix

```go
// AFTER
httpServer := &http.Server{
    Addr:              ":" + httpPort,
    Handler:           newHealthHandler(log),
    ReadHeaderTimeout: 5 * time.Second,   // ← new
    ReadTimeout:       5 * time.Second,
    WriteTimeout:      5 * time.Second,
}
```

A comment explaining why `ReadHeaderTimeout` is the important field has been added to help future maintainers.

## Testing steps

1. `go build ./cmd/server/...` — must compile cleanly.
2. Start the server and `curl http://localhost:8080/health` — should return `{"status":"ok"}`.
3. To exercise the timeout: `nc localhost 8080`, type `GET / HTTP/1.1\r\n` and then wait — the connection should be closed after 5 seconds.

## Audit note

**Reviewed:** `cmd/server/main.go`, `go.mod`, `Dockerfile`, `cmd/sync/`, `cmd/taggen/`.

**Other findings (not fixed here):**
- gRPC server uses a `UnaryInterceptor` for auth — no stream interceptor is registered. If `StreamInterceptor` is needed in the future, auth must be added there too.
- `database.AutoMigrate()` runs synchronously at startup, which is acceptable for the current scale.
- Dependencies appear current (`go 1.25.0`, recent module versions).
- No open `audit/` PRs conflicted with this change.
