### PR TITLE
fix(logger): distinguish service names per binary (server/sync/taggen)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -38,7 +38,7 @@ var (
 )
 
 func main() {
-	log := logger.New()
+	log := logger.New("etu-backend-server")
 
 	// rootCtx carries the application logger so any code path that derives a
 	// context (HTTP handlers, gRPC interceptors, background goroutines) can

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 func main() {
-	log := logger.New()
+	log := logger.New("etu-backend-sync")
 	rootCtx := logging.NewContext(context.Background(), log)
 
 	fullSync := flag.Bool("full", false, "Perform a full sync instead of incremental")

--- a/cmd/taggen/main.go
+++ b/cmd/taggen/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	log := logger.New()
+	log := logger.New("etu-backend-taggen")
 
 	// rootCtx carries the application logger so descendant contexts
 	// (signal-cancellable, per-task) can retrieve it via logging.FromContext.

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -2,6 +2,11 @@
 // icco/gutil/logging (a thin wrapper over zap). Loggers are propagated via
 // context.Context throughout the codebase using logging.NewContext /
 // logging.FromContext.
+//
+// Each binary entrypoint is expected to pass its own service name to New so
+// that logs emitted by the different binaries built from this repo
+// (cmd/server, cmd/sync, cmd/taggen) can be distinguished in log
+// aggregators.
 package logger
 
 import (
@@ -9,11 +14,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const service = "etu-backend"
-
-// New returns the application logger. Most call sites should use
-// logging.FromContext(ctx) instead of this directly; New is kept for the
-// process entrypoint that needs to seed the root context.
-func New() *zap.SugaredLogger {
+// New returns the application logger tagged with the given service name.
+// Most call sites should use logging.FromContext(ctx) instead of this
+// directly; New is kept for the process entrypoint that needs to seed the
+// root context.
+func New(service string) *zap.SugaredLogger {
 	return logging.Must(logging.NewLogger(service))
 }


### PR DESCRIPTION
All three binaries built from this image (`cmd/server`, `cmd/sync`, `cmd/taggen`) previously logged with `service=etu-backend`, making it impossible to filter by binary in log aggregators.

`logger.New` now takes a service name; each entrypoint passes `etu-backend-server`, `etu-backend-sync`, or `etu-backend-taggen` respectively.

Made with [Cursor](https://cursor.com)