### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN task build
 FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.source=https://github.com/icco/etu-backend
-LABEL org.opencontainers.image.description="ghcr.io/icco/etu-backend container image"
+LABEL org.opencontainers.image.description="gRPC notes/tags API in Go backing etu-web and the etu CLI; Postgres storage, GCS attachments, Notion sync, and Gemini-powered tag generation, OCR, and audio transcription."
 LABEL org.opencontainers.image.licenses=CC-BY-NC-4.0
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN task build
 # Final image
 FROM debian:bookworm-slim
 
+LABEL org.opencontainers.image.source=https://github.com/icco/etu-backend
+LABEL org.opencontainers.image.description="ghcr.io/icco/etu-backend container image"
+LABEL org.opencontainers.image.licenses=CC-BY-NC-4.0
+
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user.


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)