### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,7 +41,13 @@ const statusKey = "status"
 
 func main() {
 	log := logger.New("etu-backend-server")
+	if err := run(log); err != nil {
+		log.Errorw("server exited with error", zap.Error(err))
+		os.Exit(1)
+	}
+}
 
+func run(log *zap.SugaredLogger) error {
 	// rootCtx carries the application logger so any code path that derives a
 	// context (HTTP handlers, gRPC interceptors, background goroutines) can
 	// retrieve a logger via logging.FromContext.
@@ -65,8 +71,7 @@ func main() {
 	registry := prometheus.NewRegistry()
 	exporter, err := otelprom.New(otelprom.WithRegisterer(registry))
 	if err != nil {
-		log.Errorw("failed to init prometheus exporter", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to init prometheus exporter: %w", err)
 	}
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
 	otel.SetMeterProvider(mp)
@@ -80,8 +85,7 @@ func main() {
 
 	database, err := db.New()
 	if err != nil {
-		log.Errorw("failed to connect to database", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer func() {
 		if err := database.Close(); err != nil {
@@ -90,15 +94,13 @@ func main() {
 	}()
 
 	if err := database.AutoMigrate(); err != nil {
-		log.Errorw("failed to run database migrations", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to run database migrations: %w", err)
 	}
 	log.Infow("database initialized and migrations completed")
 
 	authenticator, err := auth.New()
 	if err != nil {
-		log.Errorw("failed to initialize authenticator", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize authenticator: %w", err)
 	}
 	defer func() {
 		if err := authenticator.Close(); err != nil {
@@ -167,10 +169,10 @@ func main() {
 
 	reflection.Register(server)
 
-	grpcListener, err := net.Listen("tcp", ":"+grpcPort)
+	var lc net.ListenConfig
+	grpcListener, err := lc.Listen(rootCtx, "tcp", ":"+grpcPort)
 	if err != nil {
-		log.Errorw("failed to listen on gRPC port", "port", grpcPort, zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to listen on gRPC port %s: %w", grpcPort, err)
 	}
 
 	// Create HTTP server for health checks.
@@ -217,6 +219,7 @@ func main() {
 	server.GracefulStop()
 
 	log.Infow("servers stopped gracefully")
+	return nil
 }
 
 // newHealthHandler creates an HTTP handler for health check and metrics
@@ -242,7 +245,7 @@ func newHealthHandler(log *zap.SugaredLogger, metrics http.Handler) http.Handler
 		}
 	})
 
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(map[string]string{
@@ -253,7 +256,7 @@ func newHealthHandler(log *zap.SugaredLogger, metrics http.Handler) http.Handler
 		}
 	})
 
-	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		if _, err := fmt.Fprint(w, "User-agent: *\nDisallow: /\n"); err != nil {
@@ -261,7 +264,7 @@ func newHealthHandler(log *zap.SugaredLogger, metrics http.Handler) http.Handler
 		}
 	})
 
-	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(map[string]string{

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -24,6 +25,13 @@ const (
 
 func main() {
 	log := logger.New("etu-backend-sync")
+	if err := run(log); err != nil {
+		log.Errorw("sync exited with error", zap.Error(err))
+		os.Exit(1)
+	}
+}
+
+func run(log *zap.SugaredLogger) error {
 	rootCtx := logging.NewContext(context.Background(), log)
 
 	fullSync := flag.Bool("full", false, "Perform a full sync instead of incremental")
@@ -37,8 +45,7 @@ func main() {
 		dirBidirectional: true,
 	}
 	if !validDirections[*direction] {
-		log.Errorw("invalid direction value", "direction", *direction, "valid_options", []string{dirFromNotion, dirToNotion, dirBidirectional})
-		os.Exit(1)
+		return fmt.Errorf("invalid direction value %q (valid: %s, %s, %s)", *direction, dirFromNotion, dirToNotion, dirBidirectional)
 	}
 
 	intervalStr := "once"
@@ -54,8 +61,7 @@ func main() {
 
 	database, err := syncdb.New()
 	if err != nil {
-		log.Errorw("failed to connect to database", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer func() {
 		if err := database.Close(); err != nil {
@@ -64,8 +70,7 @@ func main() {
 	}()
 
 	if err := database.AutoMigrate(); err != nil {
-		log.Errorw("failed to run migrations", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to run migrations: %w", err)
 	}
 	log.Infow("database connected and migrations completed")
 
@@ -86,6 +91,7 @@ func main() {
 	} else {
 		runOnce(ctx, database, *fullSync, *direction)
 	}
+	return nil
 }
 
 func runOnce(ctx context.Context, database *syncdb.DB, fullSync bool, syncMode string) {

--- a/cmd/taggen/main.go
+++ b/cmd/taggen/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -21,7 +22,13 @@ import (
 
 func main() {
 	log := logger.New("etu-backend-taggen")
+	if err := run(log); err != nil {
+		log.Errorw("taggen exited with error", zap.Error(err))
+		os.Exit(1)
+	}
+}
 
+func run(log *zap.SugaredLogger) error {
 	// rootCtx carries the application logger so descendant contexts
 	// (signal-cancellable, per-task) can retrieve it via logging.FromContext.
 	rootCtx := logging.NewContext(context.Background(), log)
@@ -32,26 +39,22 @@ func main() {
 
 	geminiProject := os.Getenv("GEMINI_PROJECT")
 	if geminiProject == "" {
-		log.Errorw("GEMINI_PROJECT environment variable not set")
-		os.Exit(1)
+		return fmt.Errorf("GEMINI_PROJECT environment variable not set")
 	}
 
 	gcsBucket := os.Getenv("GCS_BUCKET")
 	if gcsBucket == "" {
-		log.Errorw("GCS_BUCKET environment variable not set")
-		os.Exit(1)
+		return fmt.Errorf("GCS_BUCKET environment variable not set")
 	}
 
 	aiClient, err := ai.NewClient(geminiProject, os.Getenv("GEMINI_LOCATION"))
 	if err != nil {
-		log.Errorw("failed to initialize AI client", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize AI client: %w", err)
 	}
 
 	storageClient, err := storage.New(rootCtx, gcsBucket)
 	if err != nil {
-		log.Errorw("failed to initialize storage client", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize storage client: %w", err)
 	}
 	defer func() {
 		if err := storageClient.Close(); err != nil {
@@ -71,8 +74,7 @@ func main() {
 
 	database, err := db.New()
 	if err != nil {
-		log.Errorw("failed to connect to database", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer func() {
 		if err := database.Close(); err != nil {
@@ -106,24 +108,20 @@ func main() {
 			select {
 			case <-processCtx.Done():
 				log.Infow("shutting down AI processing job")
-				return
+				return nil
 			case <-ticker.C:
 				processOnce(processCtx, database, aiClient, storageClient, *dryRun, rateLimiter)
 			}
 		}
-	} else {
-		processOnce(processCtx, database, aiClient, storageClient, *dryRun, rateLimiter)
 	}
+	processOnce(processCtx, database, aiClient, storageClient, *dryRun, rateLimiter)
+	return nil
 }
 
 func processOnce(ctx context.Context, database *db.DB, aiClient *ai.Client, storageClient *storage.Client, dryRun bool, rateLimiter *rate.Limiter) {
 	l := logging.FromContext(ctx)
 
-	result, err := processAllTasks(ctx, database, aiClient, storageClient, dryRun, rateLimiter)
-	if err != nil {
-		l.Errorw("AI processing failed", zap.Error(err))
-		return
-	}
+	result := processAllTasks(ctx, database, aiClient, storageClient, dryRun, rateLimiter)
 
 	l.Infow("AI processing completed",
 		"duration", result.Duration.String(),
@@ -146,8 +144,8 @@ type ProcessResult struct {
 	Duration        time.Duration
 }
 
-// processAllTasks runs all AI processing tasks in parallel: tag generation, OCR, and audio transcription
-func processAllTasks(ctx context.Context, database *db.DB, aiClient *ai.Client, storageClient *storage.Client, dryRun bool, rateLimiter *rate.Limiter) (*ProcessResult, error) {
+// processAllTasks runs all AI processing tasks in parallel: tag generation, OCR, and audio transcription.
+func processAllTasks(ctx context.Context, database *db.DB, aiClient *ai.Client, storageClient *storage.Client, dryRun bool, rateLimiter *rate.Limiter) *ProcessResult {
 	l := logging.FromContext(ctx)
 
 	start := time.Now()
@@ -196,7 +194,7 @@ func processAllTasks(ctx context.Context, database *db.DB, aiClient *ai.Client, 
 	wg.Wait()
 
 	result.Duration = time.Since(start)
-	return result, nil
+	return result
 }
 
 // processImagesWithoutText processes all images that don't have extracted text yet

--- a/internal/ai/sanitize_test.go
+++ b/internal/ai/sanitize_test.go
@@ -107,11 +107,9 @@ func TestSanitizeUserContent(t *testing.T) {
 						t.Errorf("sanitizeUserContent() should contain [filtered] marker for injection attempt, got %q", got)
 					}
 				}
-			} else {
+			} else if got != tt.input {
 				// Content should pass through unchanged
-				if got != tt.input {
-					t.Errorf("sanitizeUserContent() = %q, want %q (clean content should not be modified)", got, tt.input)
-				}
+				t.Errorf("sanitizeUserContent() = %q, want %q (clean content should not be modified)", got, tt.input)
 			}
 		})
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/icco/gutil/logging"
-	_ "github.com/lib/pq"
+	_ "github.com/lib/pq" // register the postgres database/sql driver
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -73,7 +73,9 @@ func New() (*Authenticator, error) {
 		return nil, fmt.Errorf("failed to open database connection: %w", err)
 	}
 
-	if err := conn.Ping(); err != nil {
+	pingCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := conn.PingContext(pingCtx); err != nil {
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
@@ -121,6 +123,10 @@ func (a *Authenticator) VerifyAPIKey(ctx context.Context, apiKey string) (string
 		}
 
 		if err := bcrypt.CompareHashAndPassword([]byte(keyHash), []byte(apiKey)); err == nil {
+			// Detach from request ctx so the audit write can outlive the
+			// request, but preserve the logger so the async update stays
+			// correlated.
+			//nolint:contextcheck // background goroutine intentionally detached
 			go a.updateLastUsed(logging.NewContext(context.Background(), l), id)
 			return userID, nil
 		}

--- a/internal/auth/m2m.go
+++ b/internal/auth/m2m.go
@@ -22,9 +22,9 @@ func NewM2MConfig(ctx context.Context) *M2MConfig {
 	l := logging.FromContext(ctx)
 	config := &M2MConfig{}
 
-	grpcApiKeys := os.Getenv("GRPC_API_KEYS")
-	if grpcApiKeys != "" {
-		rawTokens := strings.Split(grpcApiKeys, ",")
+	grpcAPIKeys := os.Getenv("GRPC_API_KEYS")
+	if grpcAPIKeys != "" {
+		rawTokens := strings.Split(grpcAPIKeys, ",")
 		for _, token := range rawTokens {
 			trimmed := strings.TrimSpace(token)
 			if trimmed != "" {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -26,13 +26,23 @@ type DB struct {
 	conn *gorm.DB
 }
 
-// Re-export models for backwards compatibility
-type Note = models.Note
-type Tag = models.Tag
-type User = models.User
-type ApiKey = models.ApiKey
-type NoteImage = models.NoteImage
-type NoteAudio = models.NoteAudio
+// Re-exported model types for backwards compatibility.
+type (
+	// Note is an alias for models.Note.
+	Note = models.Note
+	// Tag is an alias for models.Tag.
+	Tag = models.Tag
+	// User is an alias for models.User.
+	User = models.User
+	// ApiKey is an alias for models.ApiKey.
+	//
+	//nolint:revive // matches proto-generated pb.ApiKey
+	ApiKey = models.ApiKey
+	// NoteImage is an alias for models.NoteImage.
+	NoteImage = models.NoteImage
+	// NoteAudio is an alias for models.NoteAudio.
+	NoteAudio = models.NoteAudio
+)
 
 // encryptNotionKey encrypts a Notion API key if encryption is available.
 // If ENCRYPTION_KEY is not set, it logs a warning and returns the plaintext.
@@ -933,7 +943,9 @@ func (db *DB) EnableUser(ctx context.Context, userID string) error {
 	return nil
 }
 
-// CreateApiKey creates a new API key for a user
+// CreateApiKey creates a new API key for a user.
+//
+//nolint:revive // matches proto-generated naming
 func (db *DB) CreateApiKey(ctx context.Context, userID, name, keyPrefix, keyHash string) (*ApiKey, error) {
 	now := time.Now()
 	apiKey := ApiKey{
@@ -952,7 +964,9 @@ func (db *DB) CreateApiKey(ctx context.Context, userID, name, keyPrefix, keyHash
 	return &apiKey, nil
 }
 
-// ListApiKeys retrieves all API keys for a user (without the hash)
+// ListApiKeys retrieves all API keys for a user (without the hash).
+//
+//nolint:revive // matches proto-generated naming
 func (db *DB) ListApiKeys(ctx context.Context, userID string) ([]ApiKey, error) {
 	var keys []ApiKey
 	err := db.conn.WithContext(ctx).
@@ -966,7 +980,9 @@ func (db *DB) ListApiKeys(ctx context.Context, userID string) ([]ApiKey, error) 
 	return keys, nil
 }
 
-// DeleteApiKey deletes an API key for a user
+// DeleteApiKey deletes an API key for a user.
+//
+//nolint:revive // matches proto-generated naming
 func (db *DB) DeleteApiKey(ctx context.Context, userID, keyID string) (bool, error) {
 	result := db.conn.WithContext(ctx).Where(`id = ? AND "userId" = ?`, keyID, userID).Delete(&ApiKey{})
 	if result.Error != nil {
@@ -975,7 +991,9 @@ func (db *DB) DeleteApiKey(ctx context.Context, userID, keyID string) (bool, err
 	return result.RowsAffected > 0, nil
 }
 
-// GetApiKeysByPrefix retrieves API keys by prefix for verification
+// GetApiKeysByPrefix retrieves API keys by prefix for verification.
+//
+//nolint:revive // matches proto-generated naming
 func (db *DB) GetApiKeysByPrefix(ctx context.Context, keyPrefix string) ([]ApiKey, error) {
 	var keys []ApiKey
 	err := db.conn.WithContext(ctx).Where(`"keyPrefix" = ?`, keyPrefix).Find(&keys).Error
@@ -985,7 +1003,9 @@ func (db *DB) GetApiKeysByPrefix(ctx context.Context, keyPrefix string) ([]ApiKe
 	return keys, nil
 }
 
-// UpdateApiKeyLastUsed updates the lastUsed timestamp for an API key
+// UpdateApiKeyLastUsed updates the lastUsed timestamp for an API key.
+//
+//nolint:revive // matches proto-generated naming
 func (db *DB) UpdateApiKeyLastUsed(ctx context.Context, keyID string) error {
 	return db.conn.WithContext(ctx).Model(&ApiKey{}).Where("id = ?", keyID).Update("lastUsed", time.Now()).Error
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -121,7 +121,9 @@ func (User) TableName() string {
 	return "User"
 }
 
-// ApiKey represents an API key in the database
+// ApiKey represents an API key in the database.
+//
+//nolint:revive // matches proto-generated pb.ApiKey
 type ApiKey struct {
 	ID        string     `gorm:"column:id;primaryKey"`
 	Name      string     `gorm:"column:name"`
@@ -149,7 +151,7 @@ func (SyncState) TableName() string {
 }
 
 // BeforeCreate hook to generate CUID-like ID for notes
-func (n *Note) BeforeCreate(tx *gorm.DB) error {
+func (n *Note) BeforeCreate(_ *gorm.DB) error {
 	if n.ID == "" {
 		n.ID = GenerateCUID()
 	}
@@ -157,7 +159,7 @@ func (n *Note) BeforeCreate(tx *gorm.DB) error {
 }
 
 // BeforeCreate hook to generate CUID-like ID for tags
-func (t *Tag) BeforeCreate(tx *gorm.DB) error {
+func (t *Tag) BeforeCreate(_ *gorm.DB) error {
 	if t.ID == "" {
 		t.ID = GenerateCUID()
 	}
@@ -165,7 +167,7 @@ func (t *Tag) BeforeCreate(tx *gorm.DB) error {
 }
 
 // BeforeCreate hook to generate CUID-like ID for users
-func (u *User) BeforeCreate(tx *gorm.DB) error {
+func (u *User) BeforeCreate(_ *gorm.DB) error {
 	if u.ID == "" {
 		u.ID = GenerateCUID()
 	}
@@ -173,7 +175,7 @@ func (u *User) BeforeCreate(tx *gorm.DB) error {
 }
 
 // BeforeCreate hook to generate CUID-like ID for API keys
-func (a *ApiKey) BeforeCreate(tx *gorm.DB) error {
+func (a *ApiKey) BeforeCreate(_ *gorm.DB) error {
 	if a.ID == "" {
 		a.ID = GenerateCUID()
 	}
@@ -181,7 +183,7 @@ func (a *ApiKey) BeforeCreate(tx *gorm.DB) error {
 }
 
 // BeforeCreate hook to generate CUID-like ID for note images
-func (ni *NoteImage) BeforeCreate(tx *gorm.DB) error {
+func (ni *NoteImage) BeforeCreate(_ *gorm.DB) error {
 	if ni.ID == "" {
 		ni.ID = GenerateCUID()
 	}
@@ -189,7 +191,7 @@ func (ni *NoteImage) BeforeCreate(tx *gorm.DB) error {
 }
 
 // BeforeCreate hook to generate CUID-like ID for note audios
-func (na *NoteAudio) BeforeCreate(tx *gorm.DB) error {
+func (na *NoteAudio) BeforeCreate(_ *gorm.DB) error {
 	if na.ID == "" {
 		na.ID = GenerateCUID()
 	}

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -227,7 +227,7 @@ func (c *Client) processPages(ctx context.Context, client *notionapi.Client, pag
 
 	// Collect results in order
 	posts := make([]*Post, len(pages))
-	for i := 0; i < len(pages); i++ {
+	for range pages {
 		result := <-results
 		if result.err != nil {
 			return nil, result.err
@@ -427,7 +427,7 @@ func (c *Client) replacePageContent(ctx context.Context, client *notionapi.Clien
 		}
 
 		for _, block := range blockResp.Results {
-			blockIDs = append(blockIDs, notionapi.BlockID(block.GetID()))
+			blockIDs = append(blockIDs, block.GetID())
 		}
 
 		if !blockResp.HasMore {

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -14,18 +14,27 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// ApiKeysService implements the ApiKeysService gRPC service
+// ApiKeysService implements the ApiKeysService gRPC service.
+// The "Api" naming mirrors the proto-generated identifiers
+// (pb.ApiKey, pb.ApiKeysServiceServer); renaming to the Go-idiomatic
+// "APIKey" would break the gRPC server interface contract.
+//
+//nolint:revive // proto-generated naming
 type ApiKeysService struct {
 	pb.UnimplementedApiKeysServiceServer
 	db *db.DB
 }
 
-// NewApiKeysService creates a new ApiKeysService
+// NewApiKeysService creates a new ApiKeysService.
+//
+//nolint:revive // proto-generated naming
 func NewApiKeysService(database *db.DB) *ApiKeysService {
 	return &ApiKeysService{db: database}
 }
 
-// CreateApiKey creates a new API key for a user
+// CreateApiKey creates a new API key for a user.
+//
+//nolint:revive // proto-generated naming
 func (s *ApiKeysService) CreateApiKey(ctx context.Context, req *pb.CreateApiKeyRequest) (*pb.CreateApiKeyResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
@@ -67,7 +76,9 @@ func (s *ApiKeysService) CreateApiKey(ctx context.Context, req *pb.CreateApiKeyR
 	}, nil
 }
 
-// ListApiKeys lists all API keys for a user
+// ListApiKeys lists all API keys for a user.
+//
+//nolint:revive // proto-generated naming
 func (s *ApiKeysService) ListApiKeys(ctx context.Context, req *pb.ListApiKeysRequest) (*pb.ListApiKeysResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
@@ -93,7 +104,9 @@ func (s *ApiKeysService) ListApiKeys(ctx context.Context, req *pb.ListApiKeysReq
 	}, nil
 }
 
-// DeleteApiKey deletes an API key
+// DeleteApiKey deletes an API key.
+//
+//nolint:revive // proto-generated naming
 func (s *ApiKeysService) DeleteApiKey(ctx context.Context, req *pb.DeleteApiKeyRequest) (*pb.DeleteApiKeyResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
@@ -117,7 +130,9 @@ func (s *ApiKeysService) DeleteApiKey(ctx context.Context, req *pb.DeleteApiKeyR
 	}, nil
 }
 
-// VerifyApiKey verifies an API key and returns the associated user ID
+// VerifyApiKey verifies an API key and returns the associated user ID.
+//
+//nolint:revive,contextcheck // proto-generated naming; background goroutine intentionally detached from request context
 func (s *ApiKeysService) VerifyApiKey(ctx context.Context, req *pb.VerifyApiKeyRequest) (*pb.VerifyApiKeyResponse, error) {
 	if req.RawKey == "" {
 		return nil, status.Error(codes.InvalidArgument, "raw_key is required")

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -129,7 +129,9 @@ func (s *AuthService) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.
 	}, nil
 }
 
-// GetUserByStripeCustomerId retrieves a user by Stripe customer ID
+// GetUserByStripeCustomerId retrieves a user by Stripe customer ID.
+//
+//nolint:revive // proto-generated naming
 func (s *AuthService) GetUserByStripeCustomerId(ctx context.Context, req *pb.GetUserByStripeCustomerIdRequest) (*pb.GetUserByStripeCustomerIdResponse, error) {
 	if req.StripeCustomerId == "" {
 		return nil, status.Error(codes.InvalidArgument, "stripe_customer_id is required")

--- a/internal/service/notes.go
+++ b/internal/service/notes.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// Note size and pagination limits applied by the NotesService API.
 const (
 	MaxNotesLimit     = 100
 	DefaultNotesLimit = 50

--- a/internal/service/notes_test.go
+++ b/internal/service/notes_test.go
@@ -51,7 +51,7 @@ func mockNoteToProto(n *db.Note) *pb.Note {
 	}
 }
 
-func (s *mockNotesService) CreateNote(ctx context.Context, req *pb.CreateNoteRequest) (*pb.CreateNoteResponse, error) {
+func (s *mockNotesService) CreateNote(_ context.Context, req *pb.CreateNoteRequest) (*pb.CreateNoteResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
 	}
@@ -86,7 +86,7 @@ func (s *mockNotesService) CreateNote(ctx context.Context, req *pb.CreateNoteReq
 	}, nil
 }
 
-func (s *mockNotesService) GetNote(ctx context.Context, req *pb.GetNoteRequest) (*pb.GetNoteResponse, error) {
+func (s *mockNotesService) GetNote(_ context.Context, req *pb.GetNoteRequest) (*pb.GetNoteResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
 	}
@@ -104,7 +104,7 @@ func (s *mockNotesService) GetNote(ctx context.Context, req *pb.GetNoteRequest) 
 	}, nil
 }
 
-func (s *mockNotesService) ListNotes(ctx context.Context, req *pb.ListNotesRequest) (*pb.ListNotesResponse, error) {
+func (s *mockNotesService) ListNotes(_ context.Context, req *pb.ListNotesRequest) (*pb.ListNotesResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
 	}
@@ -124,7 +124,7 @@ func (s *mockNotesService) ListNotes(ctx context.Context, req *pb.ListNotesReque
 	}, nil
 }
 
-func (s *mockNotesService) DeleteNote(ctx context.Context, req *pb.DeleteNoteRequest) (*pb.DeleteNoteResponse, error) {
+func (s *mockNotesService) DeleteNote(_ context.Context, req *pb.DeleteNoteRequest) (*pb.DeleteNoteResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
 	}
@@ -141,7 +141,7 @@ func (s *mockNotesService) DeleteNote(ctx context.Context, req *pb.DeleteNoteReq
 	return &pb.DeleteNoteResponse{Success: true}, nil
 }
 
-func (s *mockNotesService) GetRandomNotes(ctx context.Context, req *pb.GetRandomNotesRequest) (*pb.GetRandomNotesResponse, error) {
+func (s *mockNotesService) GetRandomNotes(_ context.Context, req *pb.GetRandomNotesRequest) (*pb.GetRandomNotesResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
 	}
@@ -169,7 +169,7 @@ func (s *mockNotesService) GetRandomNotes(ctx context.Context, req *pb.GetRandom
 	rand.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
 
 	notes := make([]*pb.Note, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		notes[i] = mockNoteToProto(shuffled[i])
 	}
 
@@ -590,7 +590,7 @@ func TestGetRandomNotes(t *testing.T) {
 
 		// Collect orderings from multiple calls (by note IDs)
 		orderings := make([][]string, 0, 20)
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			resp, err := svc.GetRandomNotes(ctx, &pb.GetRandomNotesRequest{
 				UserId: testUserID1,
 				Count:  5,
@@ -610,7 +610,7 @@ func TestGetRandomNotes(t *testing.T) {
 
 		// At least two responses must differ in order (proves we're not always returning same order)
 		var seenDifferent bool
-		for i := 0; i < len(orderings); i++ {
+		for i := range orderings {
 			for j := i + 1; j < len(orderings); j++ {
 				if !sliceEqual(orderings[i], orderings[j]) {
 					seenDifferent = true

--- a/internal/service/stats_test.go
+++ b/internal/service/stats_test.go
@@ -17,7 +17,7 @@ type mockStatsDB struct {
 	shouldError  bool
 }
 
-func (m *mockStatsDB) GetStats(ctx context.Context, userID string) (int64, int64, int64, error) {
+func (m *mockStatsDB) GetStats(_ context.Context, _ string) (int64, int64, int64, error) {
 	if m.shouldError {
 		return 0, 0, 0, status.Error(codes.Internal, "database error")
 	}

--- a/internal/service/tags_test.go
+++ b/internal/service/tags_test.go
@@ -35,7 +35,7 @@ func (s *mockTagsService) addTag(userID, name string, count int) {
 	s.tags[tag.ID] = tag
 }
 
-func (s *mockTagsService) ListTags(ctx context.Context, req *pb.ListTagsRequest) (*pb.ListTagsResponse, error) {
+func (s *mockTagsService) ListTags(_ context.Context, req *pb.ListTagsRequest) (*pb.ListTagsResponse, error) {
 	if req.UserId == "" {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
 	}

--- a/internal/storage/gcs.go
+++ b/internal/storage/gcs.go
@@ -71,7 +71,7 @@ func (c *Client) UploadImage(ctx context.Context, objectName string, data []byte
 
 // GetSignedURL generates a signed URL for accessing an object.
 // The URL is valid for SignedURLDuration.
-func (c *Client) GetSignedURL(ctx context.Context, objectName string) (string, error) {
+func (c *Client) GetSignedURL(_ context.Context, objectName string) (string, error) {
 	opts := &storage.SignedURLOptions{
 		Scheme:  storage.SigningSchemeV4,
 		Method:  "GET",

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -26,8 +26,8 @@ func NewSyncer(database *syncdb.DB, notionClient *notion.Client) *Syncer {
 	}
 }
 
-// SyncResult contains statistics from a sync operation.
-type SyncResult struct {
+// Result contains statistics from a sync operation.
+type Result struct {
 	Created   int
 	Updated   int
 	Unchanged int
@@ -35,8 +35,8 @@ type SyncResult struct {
 	Duration  time.Duration
 }
 
-// SyncToNotionResult contains statistics from syncing back to Notion.
-type SyncToNotionResult struct {
+// ToNotionResult contains statistics from syncing back to Notion.
+type ToNotionResult struct {
 	Created  int
 	Updated  int
 	Archived int
@@ -46,11 +46,11 @@ type SyncToNotionResult struct {
 
 // SyncUser syncs all Notion posts for a specific user to the database.
 // If fullSync is true, it fetches all posts; otherwise it only fetches posts modified since last sync.
-func (s *Syncer) SyncUser(ctx context.Context, userID string, fullSync bool) (*SyncResult, error) {
+func (s *Syncer) SyncUser(ctx context.Context, userID string, fullSync bool) (*Result, error) {
 	l := logging.FromContext(ctx).With("user_id", userID)
 
 	start := time.Now()
-	result := &SyncResult{}
+	result := &Result{}
 
 	var posts []*notion.Post
 	var err error
@@ -104,11 +104,12 @@ func (s *Syncer) SyncUser(ctx context.Context, userID string, fullSync bool) (*S
 			continue
 		}
 
-		if isNew {
+		switch {
+		case isNew:
 			result.Created++
-		} else if existing != nil && (existing.Content != post.Text || !s.tagsChanged(existing.ID, post.Tags)) {
+		case existing != nil && (existing.Content != post.Text || !s.tagsChanged(existing.ID, post.Tags)):
 			result.Updated++
-		} else {
+		default:
 			result.Unchanged++
 		}
 	}
@@ -149,11 +150,11 @@ func (s *Syncer) tagsChanged(noteID string, newTags []string) bool {
 // SyncUserToNotion syncs local changes back to Notion for a specific user.
 // It creates new pages for notes without a Notion page ID, and updates
 // existing pages for notes that have been modified locally.
-func (s *Syncer) SyncUserToNotion(ctx context.Context, userID string) (*SyncToNotionResult, error) {
+func (s *Syncer) SyncUserToNotion(ctx context.Context, userID string) (*ToNotionResult, error) {
 	l := logging.FromContext(ctx).With("user_id", userID)
 
 	start := time.Now()
-	result := &SyncToNotionResult{}
+	result := &ToNotionResult{}
 
 	notes, err := s.db.GetNotesNeedingSyncToNotion(userID)
 	if err != nil {
@@ -225,7 +226,7 @@ func (s *Syncer) SyncUserToNotion(ctx context.Context, userID string) (*SyncToNo
 
 // SyncUserBidirectional performs a full bidirectional sync for a user.
 // It first syncs from Notion to the local DB, then syncs local changes back to Notion.
-func (s *Syncer) SyncUserBidirectional(ctx context.Context, userID string, fullSync bool) (*SyncResult, *SyncToNotionResult, error) {
+func (s *Syncer) SyncUserBidirectional(ctx context.Context, userID string, fullSync bool) (*Result, *ToNotionResult, error) {
 	fromNotionResult, err := s.SyncUser(ctx, userID, fullSync)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to sync from Notion: %w", err)

--- a/internal/syncdb/db.go
+++ b/internal/syncdb/db.go
@@ -23,12 +23,19 @@ type DB struct {
 	conn *gorm.DB
 }
 
-// Re-export models for backwards compatibility
-type Note = models.Note
-type Tag = models.Tag
-type NoteTag = models.NoteTag
-type User = models.User
-type SyncState = models.SyncState
+// Re-exported model types for backwards compatibility.
+type (
+	// Note is an alias for models.Note.
+	Note = models.Note
+	// Tag is an alias for models.Tag.
+	Tag = models.Tag
+	// NoteTag is an alias for models.NoteTag.
+	NoteTag = models.NoteTag
+	// User is an alias for models.User.
+	User = models.User
+	// SyncState is an alias for models.SyncState.
+	SyncState = models.SyncState
+)
 
 // decryptNotionKey decrypts a Notion API key if it's encrypted.
 // If ENCRYPTION_KEY is not set or decryption fails, it assumes the key is plaintext.
@@ -140,7 +147,8 @@ func (db *DB) UpsertNoteFromNotion(userID, notionUUID, pageID, content string, t
 			result = tx.Where(`"userId" = ? AND "externalId" = ?`, userID, pageID).First(&note)
 		}
 
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		switch {
+		case errors.Is(result.Error, gorm.ErrRecordNotFound):
 			// Create new note
 			isNew = true
 			note = Note{
@@ -155,9 +163,9 @@ func (db *DB) UpsertNoteFromNotion(userID, notionUUID, pageID, content string, t
 			if err := tx.Create(&note).Error; err != nil {
 				return fmt.Errorf("failed to create note: %w", err)
 			}
-		} else if result.Error != nil {
+		case result.Error != nil:
 			return result.Error
-		} else {
+		default:
 			// Update existing note
 			isNew = false
 			note.Content = content
@@ -307,10 +315,10 @@ func (db *DB) UpdateNoteNotionSyncTime(noteID string) error {
 		Update("lastSyncedToNotion", now).Error
 }
 
-// GetDeletedNotesWithNotionID returns notes that have been soft-deleted
-// but still have a Notion page ID (for archiving in Notion).
+// GetArchivedNotePageIDs returns Notion page IDs for notes that have been
+// soft-deleted but still need to be archived in Notion.
 // Note: This assumes you have a soft-delete mechanism. If not, this is a placeholder.
-func (db *DB) GetArchivedNotePageIDs(userID string) ([]string, error) {
+func (db *DB) GetArchivedNotePageIDs(_ string) ([]string, error) {
 	// Placeholder: This would query for soft-deleted notes
 	// For now, return empty since we don't have soft-delete implemented
 	return []string{}, nil

--- a/internal/tagging/logic.go
+++ b/internal/tagging/logic.go
@@ -97,7 +97,9 @@ func SelectGeneratedTags(generatedTags []string, existingNoteTagNames map[string
 		}
 	}
 
-	newTags := append(preferredTags, otherTags...)
+	newTags := make([]string, 0, len(preferredTags)+len(otherTags))
+	newTags = append(newTags, preferredTags...)
+	newTags = append(newTags, otherTags...)
 	if len(newTags) > maxNewTags {
 		newTags = newTags[:maxNewTags]
 	}


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters (bodyclose, misspell, gosec, errorlint, noctx, contextcheck, nilerr, wastedassign, unparam, copyloopvar, intrange, revive, gocritic, unconvert). This PR fixes the resulting 55 findings so the lint check passes.

## Changes
Grouped by linter:

- revive (most findings): rename unused params to `_`; add doc comments on exported re-export aliases, `MaxNotesLimit` const block, and `GetArchivedNotePageIDs`; rename internal `sync.SyncResult`/`SyncToNotionResult` to `Result`/`ToNotionResult`; rename `grpcApiKeys` local to `grpcAPIKeys`; add justification comment on the `_ "github.com/lib/pq"` blank import. Keep `ApiKey` naming on proto-bound identifiers (matching `pb.ApiKey`, `pb.ApiKeysServiceServer`) with `//nolint:revive` comments explaining the contract.
- gocritic (7): refactor `cmd/server`, `cmd/sync`, `cmd/taggen` `main()` to `run() error` patterns so deferred `Close` calls actually fire (`exitAfterDefer`); rewrite if-else chains to switch in `sync.go` and `syncdb/db.go`; collapse `else { if }` to `else if` in `sanitize_test.go`; rewrite `append(preferredTags, otherTags...)` in `tagging/logic.go` to avoid aliasing the backing array (`appendAssign`).
- noctx (2): switch `(*sql.DB).Ping` to `PingContext` in `auth.New`; switch `net.Listen` to `(net.ListenConfig).Listen` with the root context in `cmd/server`.
- contextcheck (1): annotate the intentionally-detached audit-write goroutines with `//nolint:contextcheck` explaining the lifetime decoupling.
- intrange (2): convert `for range len(x)` to `for range x` / `for i := range x`.
- unconvert (1): drop unnecessary `notionapi.BlockID(...)` cast in `notion/client.go`.
- unparam (1): drop the unused error return on `processAllTasks` in `cmd/taggen`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — 0 issues
- `go build ./...` — passes
- `go test ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)