### PR TITLE
fix: report an unavailable encryption key as a config error

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -14,13 +14,43 @@ import (
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/icco/gutil/logging"
+	"go.uber.org/zap"
 )
 
 var (
 	encryptionKey     []byte
 	encryptionKeyErr  error
 	encryptionKeyOnce sync.Once
+	keyErrLogOnce     sync.Once
 )
+
+// DecryptOrPlaintext decrypts a stored secret, returning it unchanged if it
+// was never encrypted.
+//
+// An unavailable encryption key is a process-wide configuration fault, not
+// evidence that this particular value is plaintext, so it is reported once at
+// error level instead of once per value.
+func DecryptOrPlaintext(ctx context.Context, stored string) string {
+	if stored == "" {
+		return ""
+	}
+
+	if _, err := GetEncryptionKey(); err != nil {
+		keyErrLogOnce.Do(func() {
+			logging.FromContext(ctx).Errorw("encryption key unavailable, storing and reading secrets as plaintext", zap.Error(err))
+		})
+		return stored
+	}
+
+	decrypted, err := Decrypt(stored)
+	if err != nil {
+		logging.FromContext(ctx).Debugw("secret is not ciphertext, using as plaintext", zap.Error(err))
+		return stored
+	}
+
+	return decrypted
+}
 
 // GetEncryptionKey retrieves the encryption key from GCP Secret Manager.
 // The key should be a base64-encoded 32-byte key for AES-256.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -60,20 +60,10 @@ func (db *DB) encryptNotionKey(ctx context.Context, key string) string {
 	return encrypted
 }
 
-// decryptNotionKey decrypts a Notion API key if it's encrypted.
-// If ENCRYPTION_KEY is not set or decryption fails, it assumes the key is plaintext.
+// decryptNotionKey decrypts a Notion API key, falling back to treating it as
+// plaintext if it was never encrypted.
 func (db *DB) decryptNotionKey(ctx context.Context, encrypted string) string {
-	if encrypted == "" {
-		return ""
-	}
-
-	decrypted, err := crypto.Decrypt(encrypted)
-	if err != nil {
-		logging.FromContext(ctx).Warnw("failed to decrypt Notion key, assuming plaintext", zap.Error(err))
-		return encrypted
-	}
-
-	return decrypted
+	return crypto.DecryptOrPlaintext(ctx, encrypted)
 }
 
 // New creates a new GORM database connection

--- a/internal/syncdb/db.go
+++ b/internal/syncdb/db.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/icco/etu-backend/internal/crypto"
 	"github.com/icco/etu-backend/internal/models"
-	"github.com/icco/gutil/logging"
-	"go.uber.org/zap"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -37,20 +35,10 @@ type (
 	SyncState = models.SyncState
 )
 
-// decryptNotionKey decrypts a Notion API key if it's encrypted.
-// If ENCRYPTION_KEY is not set or decryption fails, it assumes the key is plaintext.
+// decryptNotionKey decrypts a Notion API key, falling back to treating it as
+// plaintext if it was never encrypted.
 func (db *DB) decryptNotionKey(ctx context.Context, encrypted string) string {
-	if encrypted == "" {
-		return ""
-	}
-
-	decrypted, err := crypto.Decrypt(encrypted)
-	if err != nil {
-		logging.FromContext(ctx).Warnw("failed to decrypt Notion key, assuming plaintext", zap.Error(err))
-		return encrypted
-	}
-
-	return decrypted
+	return crypto.DecryptOrPlaintext(ctx, encrypted)
 }
 
 // New creates a new GORM database connection


### PR DESCRIPTION
etu-sync logs `failed to decrypt Notion key, assuming plaintext: failed to decode secret from base64: illegal base64 data at input byte 5` every hour on mist.

That message is misleading. The error comes from `getKeyFromGCP`, not `Decrypt` — the secret at `projects/icco-cloud/secrets/notion-encryption-key` is fetched fine but its payload isn't base64, so `GetEncryptionKey` fails for *every* value. The code reports it as though this one Notion key happened to be plaintext, and silently falls back. Net effect: nothing has ever actually been encrypted, and the real fault is buried in a per-value warning.

Splits the two cases into `crypto.DecryptOrPlaintext`, which also de-duplicates the identical helper in `internal/db` and `internal/syncdb`:

- key unavailable → error level, once per process (these run in gRPC request paths)
- value isn't ciphertext → debug

This makes the fault visible; it does not fix it. The secret still needs a version whose payload is a base64-encoded 32-byte key.